### PR TITLE
Auto-save editor text

### DIFF
--- a/src/Editor.vue
+++ b/src/Editor.vue
@@ -1,6 +1,6 @@
 <template lang="jade">
   div#Editor
-    textarea(v-model="editor")
+    textarea(v-model="editor", @keyup="save | debounce 200")
 
   div#Preview
     #rendered
@@ -8,10 +8,22 @@
 </template>
 
 <script>
+import ls from 'src/utils/localStorage'
+
 export default {
   data () {
     return {
       editor: ''
+    }
+  },
+  ready () {
+    if (ls.has('markdown-text')) {
+      this.editor = ls.get('markdown-text')
+    }
+  },
+  methods: {
+    save () {
+      ls.set('markdown-text', this.editor)
     }
   }
 }

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -1,0 +1,13 @@
+export default {
+  has (key) {
+    return Boolean(window.localStorage.getItem(key).trim())
+  },
+
+  get (key) {
+    return window.localStorage.getItem(key)
+  },
+
+  set (key, value) {
+    return window.localStorage.setItem(key, value)
+  }
+}


### PR DESCRIPTION
After the user stop typing, the text on the editor will be saved on the browser local storage.
